### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appscript==1.2.2 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "darwin"
 colorama==0.4.6 ; python_version >= "3.9" and python_version < "4.0" and platform_system == "Windows"
 lxml==4.9.2 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "darwin"
-pywin32==305 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "win32"
+pywin32>=305 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "win32"
 tqdm==4.65.0 ; python_version >= "3.9" and python_version < "4.0"


### PR DESCRIPTION
pywin32 305 not available for python 3.12 which comes with anaconda 24.1.0 modified requirements.txt to allow versions of pywin greater than 305 as well. Resolving issue #2 