### PR TITLE
Allow Versions of pywin32 > 305

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 python = "^3.9"
 tqdm = "^4.65.0"
 appscript = {version = "^1.2.2", platform = "darwin"}
-pywin32 = {version = "^305", platform = "win32"}
+pywin32 = {version = ">=305", platform = "win32"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appscript==1.2.2 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "darwin"
 colorama==0.4.6 ; python_version >= "3.9" and python_version < "4.0" and platform_system == "Windows"
 lxml==4.9.2 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "darwin"
-pywin32==305 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "win32"
+pywin32>=305 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "win32"
 tqdm==4.65.0 ; python_version >= "3.9" and python_version < "4.0"


### PR DESCRIPTION
Modified requirements to support versions of pywin32 > 305 due to issues installing with python version 3.12.1